### PR TITLE
Specify Ruby version for Rubocop

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,5 @@
+version: "2"
 plugins:
   rubocop:
     enabled: true 
+    channel: rubocop-0-60


### PR DESCRIPTION
As specified here: https://gitlab.com/gitlab-org/gitlab-foss/issues/58550